### PR TITLE
bump to 3.1.0 and update run_r10k.sh for r10k-3.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [3.1.0] Released 2019-01-15
+
+- Update ``bin/run_r10k.sh`` wrapper script for [r10k 3.0.0](https://github.com/puppetlabs/r10k/blob/master/CHANGELOG.mkd#300) compatibility and to force r10k to overwrite locally-changed files.
+
 ## [3.0.0] Released 2018-05-21
 
 - Completely rework from previous system-wide installation to be run directly from git clone
@@ -32,5 +36,7 @@
 - initial module creation
 - migration of a bunch of stuff from https://github.com/jantman/puppet-archlinux-macbookretina
 
+[3.1.0]: https://github.com/jantman/workstation-bootstrap/compare/3.0.0...3.1.0
+[3.0.0]: https://github.com/jantman/workstation-bootstrap/compare/2.0.0...3.0.0
 [2.0.0]: https://github.com/jantman/workstation-bootstrap/compare/1.1.0...2.0.0
 [1.1.0]: https://github.com/jantman/workstation-bootstrap/compare/1.0.0...1.1.0

--- a/bin/run_r10k.sh
+++ b/bin/run_r10k.sh
@@ -4,6 +4,9 @@ CLONEDIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )/.." && pwd )"
 set -x
 cd $CLONEDIR
 git fetch && git pull
-PUPPETFILE=${CLONEDIR}/Puppetfile \
-  PUPPETFILE_DIR=${CLONEDIR}/modules/r10k \
-  /usr/bin/r10k puppetfile install -v $@
+/usr/bin/r10k puppetfile install \
+  -v \
+  --moduledir=${CLONEDIR}/modules/r10k \
+  --puppetfile=${CLONEDIR}/Puppetfile \
+  --force \
+  $@

--- a/metadata.json
+++ b/metadata.json
@@ -1,10 +1,11 @@
 {
   "name": "jantman-workstation_bootstrap",
-  "version": "3.0.0",
+  "version": "3.1.0",
   "summary": "sample main repository and module, geared towards Arch Linux",
   "author": "jantman",
   "description": "This is an example of a puppet/r10k main repository for use with my archlinux_workstation and optionally archlinux_macbookretina Puppet modules. This specific repository includes some personal configuration of mine, and is intended to be forked and modified. This is intended to be a generic framework for anyone who wants to use Puppet to manage their workstation's configuration. The project provides some sane (though opinionated) defaults, and instructions for how to change them. The defaults are geared towards Arch Linux, but the core in this repository can be used for any distribution, or just as an example/starting point.",
   "dependencies": [
+
   ],
   "operatingsystem_support": [
     {


### PR DESCRIPTION
This updates the ``bin/run_r10k.sh`` script for r10k >= 3.0.0 and bumps the module version to 3.1.0.